### PR TITLE
Make the code compatible with Tyre 0.2

### DIFF
--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 name: "rip"
-version: "1.0-alpha1"
+version: "1.0-alpha2"
 maintainer: "Dario Teixeira <dario.teixeira@nleyten.com>"
 authors: ["Dario Teixeira <dario.teixeira@nleyten.com>"]
 homepage: "https://github.com/darioteixeira/rip"
@@ -26,7 +26,7 @@ depends: [
   "ocamlfind"
   "re"
   "result"
-  "tyre"
+  "tyre" {>= "0.2"}
   "uri"
 ]
 depopts: ["lwt"]


### PR DESCRIPTION
Tyre change the interface quite a bit for the 0.2 release. Points impacting RIP seem to be:
* `Tyre.conv` is now separated into two combinators, `conv` which doesn't use an option, but is not allowed to fail, and `conv_fail` which allows failures.
* The ~whole argument for compile and route is removed. tyregex don't match the whole string by default anymore. You can use `Tyre.whole_string` or `Tyre.start` and `Tyre.stop` instead.

This PR make the necessary change to make rip compatible with the new version and a minimum version to opam to ensure the right tyre version is installed.